### PR TITLE
Switch to EIGRP routing

### DIFF
--- a/samples/simu5g/simulations/NR/eigrpAircraft.xml
+++ b/samples/simu5g/simulations/NR/eigrpAircraft.xml
@@ -1,0 +1,15 @@
+<Router>
+    <Routing>
+        <EIGRP>
+            <ProcessIPv4 asNumber="1">
+                <Networks>
+                    <Network>
+                        <IPAddress>0.0.0.0</IPAddress>
+                        <Wildcard>255.255.255.255</Wildcard>
+                    </Network>
+                </Networks>
+            </ProcessIPv4>
+        </EIGRP>
+    </Routing>
+    <Routing6/>
+</Router>

--- a/samples/simu5g/simulations/NR/eigrpRouter.xml
+++ b/samples/simu5g/simulations/NR/eigrpRouter.xml
@@ -1,0 +1,17 @@
+<Router>
+    <Routing>
+        <EIGRP>
+            <ProcessIPv4 asNumber="1">
+                <Networks>
+                    <Network>
+                        <IPAddress>0.0.0.0</IPAddress>
+                        <Wildcard>255.255.255.255</Wildcard>
+                    </Network>
+                </Networks>
+                <PassiveInterface>ppp0</PassiveInterface>
+                <PassiveInterface>eth0</PassiveInterface>
+            </ProcessIPv4>
+        </EIGRP>
+    </Routing>
+    <Routing6/>
+</Router>

--- a/samples/simu5g/simulations/NR/eigrpSat.xml
+++ b/samples/simu5g/simulations/NR/eigrpSat.xml
@@ -1,0 +1,15 @@
+<Router>
+    <Routing>
+        <EIGRP>
+            <ProcessIPv4 asNumber="1">
+                <Networks>
+                    <Network>
+                        <IPAddress>0.0.0.0</IPAddress>
+                        <Wildcard>255.255.255.255</Wildcard>
+                    </Network>
+                </Networks>
+            </ProcessIPv4>
+        </EIGRP>
+    </Routing>
+    <Routing6/>
+</Router>

--- a/samples/simu5g/simulations/NR/generalnetwork.ned
+++ b/samples/simu5g/simulations/NR/generalnetwork.ned
@@ -68,8 +68,8 @@ network Hybrid5GSatNetwork
         // Fan-out for SGi/N6 so two campus routers can share the UPF
         sgiSwitch: EthernetSwitch                   { @display("p=500,450"); }
 
-        aircraft[numAircraft]: StandardHost      { @display("i=vehicle/airplane;p=rand"); }
-        sat[numSat]:        StandardHost         { @display("i=weather/satellite;p=rand"); }
+        aircraft[numAircraft]: Router      { @display("i=vehicle/airplane;p=rand"); }
+        sat[numSat]: Router         { @display("i=weather/satellite;p=rand"); }
 
     connections allowunconnected:
         //* SGi/N6 fan-out: UPF ⇄ sgiSwitch ⇄ Both routers */

--- a/samples/simu5g/simulations/NR/omnetpp.ini
+++ b/samples/simu5g/simulations/NR/omnetpp.ini
@@ -24,12 +24,16 @@ seed-set         = ${repetition}
 #  IP addressing + routing
 ############################################################
 *.configurator.addDefaultRoutes = true        # a default via the nearest router
-*.configurator.addStaticRoutes  = false       # leave dynamic work to OSPF
+*.configurator.addStaticRoutes  = false       # leave dynamic work to EIGRP
 
-# Turn OSPF on for the boxes that actually forward packets
-*.router[*].hasOspfRouting    = true
-*.aircraft[*].hasOspfRouting  = true
-*.sat[*].hasOspfRouting       = true
+# Enable EIGRP on forwarding nodes
+*.router[*].hasEigrp          = true
+*.aircraft[*].hasEigrp        = true
+*.sat[*].hasEigrp             = true
+
+*.router[*].eigrp.configData  = xmldoc("eigrpRouter.xml")
+*.aircraft[*].eigrp.configData = xmldoc("eigrpAircraft.xml")
+*.sat[*].eigrp.configData     = xmldoc("eigrpSat.xml")
 
 ############################################################
 #  Mobility models
@@ -87,6 +91,22 @@ seed-set         = ${repetition}
 *.host[*].app[0].startTime             = uniform(1s,2s)
 *.host[*].app[0].stopTime              = 120s
 
+# Additional realistic services hosted on the first three campus nodes
+*.host[0].numApps                      = 2
+*.host[0].app[1].typename              = "TcpGenericServerApp"
+*.host[0].app[1].localPort             = 80
+
+*.host[1].numApps                      = 2
+*.host[1].app[1].typename              = "UdpVideoStreamServer"
+*.host[1].app[1].videoSize             = 10MiB
+*.host[1].app[1].localPort             = 3088
+*.host[1].app[1].sendInterval          = 10ms
+*.host[1].app[1].packetLen             = 1000B
+
+*.host[2].numApps                      = 2
+*.host[2].app[1].typename              = "SimpleVoipReceiver"
+*.host[2].app[1].localPort             = 2000
+
 # 5 G UEs (same idea, but their packets traverse gNB + core first)
 *.ue[*].numApps                        = 1
 *.ue[*].app[*].localPort = 3000
@@ -96,6 +116,29 @@ seed-set         = ${repetition}
 *.ue[*].app[0].destAddresses           = "iot[0..99] host[0..9]"
 *.ue[*].app[*].destPort = 3000 + ancestorIndex(1)
 *.ue[*].app[0].startTime               = uniform(1s,3s)
+
+# Mix of HTTP, video streaming and VoIP clients
+*.ue[0..3].numApps                     = 2
+*.ue[0..3].app[1].typename             = "TcpBasicClientApp"
+*.ue[0..3].app[1].connectAddress       = "host[0]"
+*.ue[0..3].app[1].connectPort          = 80
+*.ue[0..3].app[1].numRequestsPerSession = 1
+*.ue[0..3].app[1].requestLength        = intWithUnit(truncnormal(350B,20B))
+*.ue[0..3].app[1].replyLength          = intWithUnit(exponential(2000B))
+*.ue[0..3].app[1].thinkTime            = truncnormal(2s,3s)
+
+*.ue[4..6].numApps                     = 2
+*.ue[4..6].app[1].typename             = "UdpVideoStreamClient"
+*.ue[4..6].app[1].serverAddress        = "host[1]"
+*.ue[4..6].app[1].localPort            = 9999
+*.ue[4..6].app[1].serverPort           = 3088
+*.ue[4..6].app[1].startTime            = uniform(5s,6s)
+
+*.ue[7..9].numApps                     = 2
+*.ue[7..9].app[1].typename             = "SimpleVoipSender"
+*.ue[7..9].app[1].destAddress          = "host[2]"
+*.ue[7..9].app[1].destPort             = 2000
+*.ue[7..9].app[1].stopTime             = 120s
 
 # Aircraft primarily act as relays – sink any UDP they get
 *.aircraft[*].numApps                  = 1

--- a/samples/simu5g/simulations/NR/ospfConfig.xml
+++ b/samples/simu5g/simulations/NR/ospfConfig.xml
@@ -1,0 +1,13 @@
+<OSPFASConfig>
+    <Router name="router[*]" RFC1583Compatible="true">
+        <BroadcastInterface ifName="eth[*]" areaID="0.0.0.0" />
+        <PointToPointInterface ifName="ppp[*]" areaID="0.0.0.0" />
+        <PointToPointInterface ifName="ppp0" interfaceMode="NoOSPF" />
+    </Router>
+    <Router name="aircraft[*]" RFC1583Compatible="true">
+        <PointToPointInterface ifName="ppp[*]" areaID="0.0.0.0" />
+    </Router>
+    <Router name="sat[*]" RFC1583Compatible="true">
+        <PointToPointInterface ifName="ppp[*]" areaID="0.0.0.0" />
+    </Router>
+</OSPFASConfig>


### PR DESCRIPTION
## Summary
- switch from OSPF to EIGRP in the hybrid network configuration
- configure routers, aircraft and satellites with EIGRP
- mark campus router interfaces toward the UPF and campus switch as passive
- provide separate EIGRP XML configs per node type

## Testing
- `make -C samples/simu5g` *(fails: opp_configfilepath not found)*
- `source setenv && ./configure` *(fails: missing Python modules)*

------
https://chatgpt.com/codex/tasks/task_e_686f6c1d79d883318f48e8618fef8d8e